### PR TITLE
fix: avoid refetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The module will expose the Studio UI in development on `/_studio/`.
 
 In this directory, after running `yarn install`:
 - Run `yarn play` to start the playground, you can extends both [content-wind](https://github.com/Atinux/content-wind) or [docus](https://github.com/nuxt-themes/docus) so far.
-- Copy `ui/.env.example` to `ui/.env` and ajust based on playground port',
+- Copy `ui/.env.example` to `ui/.env` and adjust based on playground port',
 - Run `yarn dev` on another terminal and open Studio url
 
 To develop the Nuxt Studio UI in your project, install `@nuxthq/studio` on your project and run `nuxi dev` in your project instead of `yarn play`.

--- a/ui/components/ContentEditor.vue
+++ b/ui/components/ContentEditor.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, defineAsyncComponent, computed, useAttrs } from 'vue'
+import { defineComponent, defineAsyncComponent, computed } from 'vue'
 import type { UnwrapOptions } from '../composables/useEditor/types'
 
 export default defineComponent({
@@ -22,8 +22,6 @@ export default defineComponent({
   },
   emits: ['update'],
   async setup (props, { emit }) {
-    const attrs = useAttrs()
-
     if (process.server) {
       return { editor: null }
     }
@@ -37,16 +35,19 @@ export default defineComponent({
     })
 
     return {
-      attrs,
       editor
     }
   }
 })
 </script>
 
+<script lang="ts">
+
+</script>
+
 <template>
   <ClientOnly>
-    <VueEditor v-if="editor" v-bind="{ ...attrs, editor }" />
+    <VueEditor v-if="editor" v-bind="{ ...$attrs, editor }" />
     <template #fallback>
       <slot name="loading" />
     </template>

--- a/ui/composables/useEditor/utils/context.ts
+++ b/ui/composables/useEditor/utils/context.ts
@@ -41,6 +41,9 @@ export default (options: Options, renderVue: RenderVue): MilkdownPlugin => {
         if (prevMarkdown === null) {
           return
         }
+        if (markdown.trim() === prevMarkdown.trim()) {
+          return
+        }
 
         const { key, markdown: base } = unref(options.content) ?? { key: '', markdown: '', matter: {} }
 


### PR DESCRIPTION
Before that, when you move the slider, it causes rapid prefetching. I guess the root cause might be related to the parser/serializer where the diff between `markdown` and `previousMarkdown` are the tailing new line

https://user-images.githubusercontent.com/11247099/186733948-3bc936ed-f388-44a3-9658-4c007f5e28a3.mov

