### PR TITLE
fix: lazy load `useStudio`

### DIFF
--- a/src/runtime/composables/useStudio.ts
+++ b/src/runtime/composables/useStudio.ts
@@ -1,6 +1,7 @@
 import type { Ref } from 'vue'
 import { createApp, computed } from 'vue'
 import type { Storage } from 'unstorage'
+import type { ParsedContent } from '@nuxt/content/dist/runtime/types'
 // @ts-ignore
 import ContentPreviewMode from '../components/ContentPreviewMode.vue'
 import { createSingleton, mergeDraft } from '../utils'
@@ -88,16 +89,16 @@ export const useStudio = createSingleton(() => {
     }).mount(el)
   }
 
-  const findContentWithId = async (path: string) => {
+  const findContentWithId = async (path: string): Promise<ParsedContent | undefined> => {
     if (!path) {
-      return null
+      return undefined
     }
     path = path.replace(/\/$/, '')
     let content = await storage.value?.getItem(`${previewToken.value}:${path}`)
     if (!content) {
       content = await storage.value?.getItem(path)
     }
-    return content
+    return content as ParsedContent
   }
 
   return {

--- a/src/runtime/plugins/iframe.client.ts
+++ b/src/runtime/plugins/iframe.client.ts
@@ -1,13 +1,17 @@
 import type { NuxtApp } from 'nuxt/app'
-import { useStudio } from '../composables/useStudio'
 import { defineNuxtPlugin, ref, toRaw, useRouter } from '#imports'
 
-export default defineNuxtPlugin((nuxtApp: NuxtApp) => {
+export default defineNuxtPlugin(async (nuxtApp: NuxtApp) => {
   // Not in an iframe
   if (!window.parent || window.self === window.parent) {
     return
   }
   const router = useRouter()
+
+  const editorSelectedPath = ref('')
+  const isDocumentDrivenInitialHook = ref(true)
+
+  const useStudio = await import('../composables/useStudio').then(m => m.useStudio)
   const { findContentWithId } = useStudio()
 
   window.addEventListener('keydown', (e) => {
@@ -25,9 +29,6 @@ export default defineNuxtPlugin((nuxtApp: NuxtApp) => {
     }
   })
 
-  const editorSelectedPath = ref('')
-  const isDocumentDrivenInitialHook = ref(true)
-
   window.addEventListener('message', async (e) => {
     const { type, payload = {} } = e.data || {}
 
@@ -38,8 +39,8 @@ export default defineNuxtPlugin((nuxtApp: NuxtApp) => {
           editorSelectedPath.value = '/'
           router.push('/')
         } else if (content._path !== router.currentRoute.value.path) {
-          editorSelectedPath.value = content._path
-          router.push(content._path)
+          editorSelectedPath.value = content._path!
+          router.push(content._path!)
         }
         break
       }


### PR DESCRIPTION
resolves nuxtlabs/studio-app#318

There are a couple of downsides with not lazy loading

- preview logic load on every page, even when in normal rendering
- cookie value will fill after using `useCookie` in composable, which results in invalid preview. (this is the case for nuxtlabs/studio-app#318)
