### PR TITLE
fix(content): pre order contents based on files path

### DIFF
--- a/src/runtime/utils/files.ts
+++ b/src/runtime/utils/files.ts
@@ -52,5 +52,9 @@ export const mergeDraft = (dbFiles: PreviewFile[], draftAdditions: DraftFile[], 
     // File has been deleted
     mergedFiles.splice(mergedFiles.findIndex(f => f.path === deletion.path), 1)
   }
+
+  const comperable = new Intl.Collator(undefined, { numeric: true })
+  mergedFiles.sort((a, b) => comperable.compare(a.path, b.path))
+
   return mergedFiles
 }


### PR DESCRIPTION
Make sure contents will import to storage in right order

resolves nuxtlabs/studio-api#516