### PR TITLE
Schema generation helpers and dynamic icons loading

### DIFF
--- a/playground/nuxt.schema.ts
+++ b/playground/nuxt.schema.ts
@@ -1,8 +1,14 @@
-import { field } from '../src/theme'
+import { field, group } from '../src/theme'
 
 export default defineNuxtSchema({
   appConfig: {
-    someConfig: field({ type: 'string', default: 'schema default' }),
-    configFromNuxtSchema: field('boolean', true)
+    parent: group({
+      title: 'Parent',
+      description: 'Parent description',
+      fields: {
+        someConfig: field({ type: 'string', default: 'schema default' }),
+        configFromNuxtSchema: field({ type: 'boolean' })
+      }
+    })
   }
 })

--- a/src/runtime/composables/useStudio.ts
+++ b/src/runtime/composables/useStudio.ts
@@ -57,6 +57,12 @@ export const useStudio = () => {
 
   const syncPreviewAppConfig = (appConfig?: any) => {
     const _appConfig = callWithNuxt(nuxtApp, useAppConfig)
+
+    // Set dynamic icons for preview if user is using @nuxt/ui
+    if (_appConfig?.ui) {
+      _appConfig.ui.icons = { ..._appConfig.ui.icons, dynamic: true }
+    }
+
     // Using `defu` to merge with initial config
     // This is important to revert to default values for missing properties
     deepAssign(_appConfig, defu(appConfig, initialAppConfig))

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -34,8 +34,13 @@ export function deepAssign (obj: any, newObj: any) {
   for (const key in newObj) {
     const val = newObj[key]
     if (val !== null && typeof val === 'object') {
-      obj[key] = obj[key] || {}
-      deepAssign(obj[key], val)
+      // Replace array types
+      if (Array.isArray(val) && Array.isArray(obj[key])) {
+        obj[key] = val
+      } else {
+        obj[key] = obj[key] || {}
+        deepAssign(obj[key], val)
+      }
     } else {
       obj[key] = val
     }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,7 +3,7 @@ import type { JSType, Schema, InputValue } from 'untyped'
 
 export type ConfigInputsTypes =
   | Exclude<JSType, 'symbol' | 'function' | 'any' | 'bigint'>
-  | 'default' | 'icon' | 'file' | 'component' | 'design-token'
+  | 'default' | 'icon' | 'file' | 'media' | 'component' | 'design-token'
 
 export type DesignTokensInputsTypes = 'color' | 'size' | 'shadow' | 'size' | 'opacity' | 'font' | 'font-weight' | 'font-size' | 'letter-spacing'
 
@@ -56,14 +56,19 @@ const supportedFields: { [key in InputsTypes]: Schema } = {
   object: {
     type: 'object',
     tags: [
-      '@studioInput object',
-      '@studioInputObjectValueType icon'
+      '@studioInput object'
     ]
   },
   file: {
     type: 'string',
     tags: [
       '@studioInput file'
+    ]
+  },
+  media: {
+    type: 'string',
+    tags: [
+      '@studioInput media'
     ]
   },
   component: {


### PR DESCRIPTION
Two features in this PR:

## `group` helper

New `group` helper to be used in your `nuxt.schema.ts`. Used for parents, needs a `fields` array with all children fields.
 
Here is what the `nuxt.schema.ts` will look like for `UI Pro Doc Starter`:

```js
import { field, group } from '@nuxthq/studio/theme'

export default defineNuxtSchema({
  appConfig: {
    ui: group({
        title: 'UI',
        description: 'UI Customization.',
        icon: 'i-mdi-palette-outline',
        fields: {
          icons: group({
            title: 'Icons',
            description: 'Manage icons used in UI Pro.',
            icon: 'i-mdi-application-settings-outline',
            fields: {
              search: field({
                type: 'icon',
                title: 'Search Bar',
                description: 'Icon to display in the search bar.',
                icon: 'i-heroicons-magnifying-glass-20-solid',
                default: 'i-heroicons-magnifying-glass-20-solid'
              }),
              dark: field({
                type: 'icon',
                title: 'Dark mode',
                description: 'Icon of color mode button for dark mode.',
                icon: 'i-heroicons-moon-20-solid',
                default: 'i-heroicons-moon-20-solid'
              }),
              light: field({
                type: 'icon',
                title: 'Light mode',
                description: 'Icon of color mode button for light mode.',
                icon: 'i-heroicons-sun-20-solid',
                default: 'i-heroicons-sun-20-solid'
              }),
              external: field({
                type: 'icon',
                title: 'External Link',
                description: 'Icon for external link.',
                icon: 'i-heroicons-arrow-up-right-20-solid',
                default: 'i-heroicons-arrow-up-right-20-solid'
              }),
              chevron: field({
                type: 'icon',
                title: 'Chevron',
                description: 'Icon for chevron.',
                icon: 'i-heroicons-chevron-down-20-solid',
                default: 'i-heroicons-chevron-down-20-solid'
              }),
              hash: field({
                type: 'icon',
                title: 'Hash',
                description: 'Icon for hash anchors.',
                icon: 'i-heroicons-hashtag-20-solid',
                default: 'i-heroicons-hashtag-20-solid'
              })
            }
          })
        }
    }),
    header: group({
      title: 'Header',
      description: 'Header configuration.',
      icon: 'i-mdi-page-layout-header',
      fields: {
        logo: group({
          title: 'Logo',
          description: 'Footer logo configuration.',
          icon: 'i-mdi-image-filter-center-focus-strong-outline',
          fields: {
            path: field({
              type: 'media',
              title: 'Logo',
              description: 'Pick an image from your gallery.',
              icon: 'i-mdi-image',
              default: ''
            }),
            alt: field({
              type: 'string',
              title: 'Alt',
              description: 'Alt to display for accessibility.',
              icon: 'i-mdi-alphabet-latin',
              default: ''
            }),
            icon: field({
              type: 'icon',
              title: 'Icon',
              description: 'Icon to display.',
              icon: 'i-mdi-alphabet-latin',
              default: ''
            })
          }
        }),
        search: field({
          type: 'boolean',
          title: 'Search Bar',
          description: 'Hide or display the search bar.',
          icon: 'i-mdi-magnify',
          default: true
        }),
        links: field({
          type: 'array',
          title: 'Links',
          description: 'Array of link object displayed in header.',
          icon: 'i-mdi-link-variant',
          default: []
        })
      },
    }),
    footer: group({
      title: 'Footer',
      description: 'Footer configuration.',
      icon: 'i-mdi-page-layout-footer',
      fields: {
        credits: field({
          type: 'string',
          title: 'Footer credits section',
          description: 'Text to display as credits in the footer.',
          icon: 'i-mdi-circle-edit-outline',
          default: ''
        }),
        colorMode: field({
          type: 'boolean',
          title: 'Color Mode',
          description: 'Hide or display the color mode button.',
          icon: 'i-mdi-moon-waning-crescent',
          default: true
        }),
        links: field({
          type: 'array',
          title: 'Links',
          description: 'Array of link object displayed in footer.',
          icon: 'i-mdi-link-variant',
          default: []
        })
      }
    })
  }
})
```

## Dynamic icons for preview

When using `nuxt/ui` library (detected if there is a `appConfig.ui` field), we'll set the dynamic icon loading in order to load SVGs on runtime. 