### PR TITLE
feat: add `gitInfo` in `/__studio.json` and support staging API for preview mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
   "dependencies": {
     "@nuxt/kit": "^3.9.3",
     "defu": "^6.1.4",
+    "git-url-parse": "^14.0.0",
     "nuxt-component-meta": "^0.6.3",
+    "parse-git-config": "^3.0.0",
+    "pkg-types": "^1.0.3",
     "socket.io-client": "^4.7.4",
     "ufo": "^1.3.2",
     "untyped": "^1.4.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,18 @@ dependencies:
   defu:
     specifier: ^6.1.4
     version: 6.1.4
+  git-url-parse:
+    specifier: ^14.0.0
+    version: 14.0.0
   nuxt-component-meta:
     specifier: ^0.6.3
     version: 0.6.3(rollup@3.29.4)
+  parse-git-config:
+    specifier: ^3.0.0
+    version: 3.0.0
+  pkg-types:
+    specifier: ^1.0.3
+    version: 1.0.3
   socket.io-client:
     specifier: ^4.7.4
     version: 4.7.4
@@ -5570,14 +5579,12 @@ packages:
   /git-config-path@2.0.0:
     resolution: {integrity: sha512-qc8h1KIQbJpp+241id3GuAtkdyJ+IK+LIVtkiFTRKRrmddDzs3SI9CvP1QYmWBFvm1I/PWRwj//of8bgAc0ltA==}
     engines: {node: '>=4'}
-    dev: true
 
   /git-up@7.0.0:
     resolution: {integrity: sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==}
     dependencies:
       is-ssh: 1.4.0
       parse-url: 8.1.0
-    dev: true
 
   /git-url-parse@13.1.1:
     resolution: {integrity: sha512-PCFJyeSSdtnbfhSNRw9Wk96dDCNx+sogTe4YNXeXSJxt7xz5hvXekuRn9JX7m+Mf4OscCu8h+mtAl3+h5Fo8lQ==}
@@ -5589,7 +5596,6 @@ packages:
     resolution: {integrity: sha512-NnLweV+2A4nCvn4U/m2AoYu0pPKlsmhK9cknG7IMwsjFY1S2jxM+mAhsDxyxfCIGfGaD+dozsyX4b6vkYc83yQ==}
     dependencies:
       git-up: 7.0.0
-    dev: true
 
   /github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -6116,7 +6122,6 @@ packages:
 
   /ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-    dev: true
 
   /ini@2.0.0:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
@@ -6496,7 +6501,6 @@ packages:
     resolution: {integrity: sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==}
     dependencies:
       protocols: 2.0.1
-    dev: true
 
   /is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -8549,7 +8553,6 @@ packages:
     dependencies:
       git-config-path: 2.0.0
       ini: 1.3.8
-    dev: true
 
   /parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
@@ -8565,13 +8568,11 @@ packages:
     resolution: {integrity: sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==}
     dependencies:
       protocols: 2.0.1
-    dev: true
 
   /parse-url@8.1.0:
     resolution: {integrity: sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==}
     dependencies:
       parse-path: 7.0.0
-    dev: true
 
   /parse5@7.1.2:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
@@ -8661,7 +8662,7 @@ packages:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
       jsonc-parser: 3.2.0
-      mlly: 1.4.2
+      mlly: 1.5.0
       pathe: 1.1.2
 
   /pluralize@8.0.0:
@@ -9226,7 +9227,6 @@ packages:
 
   /protocols@2.0.1:
     resolution: {integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==}
-    dev: true
 
   /proxy-agent@6.3.1:
     resolution: {integrity: sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==}

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs'
 import path from 'path'
 import { defu } from 'defu'
 import { addPrerenderRoutes, installModule, defineNuxtModule, addPlugin, extendViteConfig, createResolver, logger, addComponentsDir, addServerHandler, resolveAlias, addVitePlugin } from '@nuxt/kit'
+import { findNearestFile } from 'pkg-types'
 
 const log = logger.withTag('@nuxt/studio')
 
@@ -88,9 +89,11 @@ export default defineNuxtModule<ModuleOptions>({
 
     const apiURL = process.env.NUXT_PUBLIC_STUDIO_API_URL || process.env.STUDIO_API || 'https://api.nuxt.studio'
     const publicToken = process.env.NUXT_PUBLIC_STUDIO_TOKENS
+    const gitInfo = await _getLocalGitInfo(nuxt.options.rootDir) || _getGitEnv()
     nuxt.options.runtimeConfig.studio = defu(nuxt.options.runtimeConfig.studio as any, {
       publicToken,
-      project: options.project
+      project: options.project,
+      gitInfo
     })
     nuxt.options.runtimeConfig.public.studio = defu(nuxt.options.runtimeConfig.public.studio as any, { apiURL })
 
@@ -138,3 +141,83 @@ export default defineNuxtModule<ModuleOptions>({
     })
   }
 })
+
+// --- Utilities to get git info ---
+
+interface GitInfo {
+  // Repository name
+  name: string,
+  // Repository owner/organization
+  owner: string,
+  // Repository URL
+  url: string,
+}
+
+async function _getLocalGitInfo (rootDir: string): Promise<GitInfo | void> {
+  const remote = await _getLocalGitRemote(rootDir)
+  if (!remote) {
+    return
+  }
+
+  // https://www.npmjs.com/package/git-url-parse#clipboard-example
+  const gitUrlParse = await import('git-url-parse' as string).then(r => r.default || r) as (input: string) => Record<string, string>
+  const { name, owner, source } = gitUrlParse(remote) as Record<string, string>
+  const url = `https://${source}/${owner}/${name}`
+
+  return {
+    name,
+    owner,
+    url
+  }
+}
+
+async function _getLocalGitRemote (dir: string) {
+  try {
+    // https://www.npmjs.com/package/parse-git-config#options
+    const parseGitConfig = await import('parse-git-config' as string).then(
+      m => m.promise
+    ) as (opts: { path: string }) => Promise<Record<string, Record<string, string>>>
+    const gitDir = await findNearestFile('.git/config', { startingFrom: dir })
+    const parsed = await parseGitConfig({ path: gitDir })
+    if (!parsed) {
+      return
+    }
+    const gitRemote = parsed['remote "origin"'].url
+    return gitRemote
+  } catch (err) {
+
+  }
+}
+
+function _getGitEnv (): GitInfo | void {
+  // https://github.com/unjs/std-env/issues/59
+  const envInfo = {
+    // Provider
+    provider: process.env.VERCEL_GIT_PROVIDER || // vercel
+     (process.env.GITHUB_SERVER_URL ? 'github' : undefined), // github
+    // Owner
+    owner: process.env.VERCEL_GIT_REPO_OWNER || // vercel
+      process.env.GITHUB_REPOSITORY_OWNER || // github
+      process.env.CI_PROJECT_PATH?.split('/').shift(), // gitlab
+    // Name
+    name: process.env.VERCEL_GIT_REPO_SLUG ||
+     process.env.GITHUB_REPOSITORY?.split('/').pop() || // github
+     process.env.CI_PROJECT_PATH?.split('/').splice(1).join('/'), // gitlab
+    // Url
+    url: process.env.REPOSITORY_URL // netlify
+  }
+
+  if (!envInfo.url && envInfo.provider && envInfo.owner && envInfo.name) {
+    envInfo.url = `https://${envInfo.provider}.com/${envInfo.owner}/${envInfo.name}`
+  }
+
+  if (!envInfo.name || !envInfo.owner || !envInfo.url) {
+    return
+  }
+
+  return {
+    name: envInfo.name,
+    owner: envInfo.owner,
+    url: envInfo.url
+  }
+}

--- a/src/runtime/components/ContentPreviewMode.vue
+++ b/src/runtime/components/ContentPreviewMode.vue
@@ -37,6 +37,7 @@ const closePreviewMode = async () => {
   // Remove preview token from cookie and session storage
   useCookie('previewToken').value = ''
   window.sessionStorage.removeItem('previewToken')
+  window.sessionStorage.removeItem('previewAPI')
 
   // Remove query params in url to refresh page
   await router.replace({ query: { preview: undefined } })

--- a/src/runtime/composables/useStudio.ts
+++ b/src/runtime/composables/useStudio.ts
@@ -23,6 +23,7 @@ export const useStudio = () => {
   const nuxtApp = useNuxtApp()
   const { studio: studioConfig, content: contentConfig } = useRuntimeConfig().public
   const contentPathMap = {} as Record<string, ParsedContent>
+  const apiURL = window.sessionStorage.getItem('previewAPI') || studioConfig?.apiURL
 
   // App config (required)
   const initialAppConfig = useDefaultAppConfig()
@@ -135,7 +136,7 @@ export const useStudio = () => {
     const previewToken = window.sessionStorage.getItem('previewToken')
     // Fetch preview data from station
     await $fetch<PreviewResponse>('api/projects/preview/sync', {
-      baseURL: studioConfig?.apiURL,
+      baseURL: apiURL,
       method: 'POST',
       params: {
         token: previewToken
@@ -151,7 +152,7 @@ export const useStudio = () => {
     document.body.appendChild(el)
     createApp(ContentPreviewMode, {
       previewToken,
-      apiURL: studioConfig?.apiURL,
+      apiURL,
       syncPreview,
       requestPreviewSyncAPI: requestPreviewSynchronization
     }).mount(el)
@@ -223,7 +224,7 @@ export const useStudio = () => {
   }
 
   return {
-    apiURL: studioConfig?.apiURL,
+    apiURL,
     contentStorage: storage,
 
     syncPreviewFiles,

--- a/src/runtime/plugins/preview.client.ts
+++ b/src/runtime/plugins/preview.client.ts
@@ -29,6 +29,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       previewToken.value = String(route.query.preview)
     }
     window.sessionStorage.setItem('previewToken', String(previewToken.value))
+    window.sessionStorage.setItem('previewAPI', typeof route.query.staging !== 'undefined' ? 'https://dev-api.nuxt.studio' : runtimeConfig.apiURL)
 
     // Listen to `content:storage` hook to get storage instance
     // There is some cases that `content:storage` hook is called before initializing preview

--- a/src/runtime/server/routes/studio.ts
+++ b/src/runtime/server/routes/studio.ts
@@ -62,6 +62,7 @@ export default eventHandler(async () => {
     version,
     project: studio?.project,
     tokens: studio?.publicToken,
+    gitInfo: studio?.gitInfo || {},
     // nuxt.schema for Nuxt Content frontmatter
     contentSchema: contentSchema || {},
     // app.config


### PR DESCRIPTION
Partially resolves https://github.com/nuxtlabs/studio-app/issues/1582

No need to give the team + name as we can get the git infos for the user and automatically detect the project.

On the API side, I suggest to check in priority the `gitInfo` from `__studio.json` before the the tokens.

This can give a zero config experience back to Studio 🚀 

This will also solve our issues for working with staging since we should validate directly the `gitInfo`.

For the preview on Studio staging, we should append the url with `?staging` and the preview will automatically call the staging API.