### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,7 @@ Edit your websites made with [Nuxt Content](https://content.nuxt.com/), in produ
 Install the dependency to your project:
 
 ```bash
-# NPM
-npm install --save-dev @nuxthq/studio
-# Yarn
-yarn add --dev @nuxthq/studio
-# pnpm
-pnpm add --save-dev @nuxthq/studio
+npx nuxi@latest module add studio
 ```
 
 Then, register the module in your `nuxt.config.ts`:
@@ -57,7 +52,7 @@ STUDIO_API=http://localhost:{PORT}
 You can install the latest nightly build of the Studio module by running:
 
 ```bash
-npm i @nuxthq/studio@nightly
+npx nuxi@latest module add studio
 ```
 
 ### Development


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
